### PR TITLE
Use logback driver for tools.logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/core.async "0.6.532"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [ch.qos.logback/logback-classic "1.2.3"]
                  [mysql/mysql-connector-java "5.1.39"]
                  [org.clojure/java.jdbc "0.6.1"]
                  [prismatic/schema "1.0.5"]

--- a/src/dumpa/binlog.clj
+++ b/src/dumpa/binlog.clj
@@ -1,7 +1,6 @@
 (ns dumpa.binlog
   (:require [clojure.core.async :as async :refer [>!!]]
-            [clojure.tools.logging :as log]
-            [dumpa.query :as query])
+            [clojure.tools.logging :as log])
   (:import [com.github.shyiko.mysql.binlog
             BinaryLogClient
             BinaryLogClient$EventListener

--- a/src/dumpa/core.clj
+++ b/src/dumpa/core.clj
@@ -1,17 +1,11 @@
 (ns dumpa.core
   "dumpa API for consuming MySQL database contents as streams of
   updates."
-  (:require [clojure.java.jdbc :as jdbc]
-            [clojure.core.async :as async :refer [chan >!!]]
+  (:require [clojure.core.async :as async :refer [chan]]
             [schema.core :as s]
-            [clojure.tools.logging :as log]
             [manifold.stream]
             [dumpa.query :as query]
-            [dumpa.table-schema :as table-schema]
-            [dumpa.events :as events]
-            [dumpa.stream :as stream]
-            [dumpa.binlog :as binlog]
-            [dumpa.row-format :as row-format]))
+            [dumpa.stream :as stream]))
 
 (def #^:private conn-param-defaults
   {:stream-keepalive-interval 60000

--- a/src/dumpa/events.clj
+++ b/src/dumpa/events.clj
@@ -137,9 +137,10 @@
      ::ev-delete-rows delete}))
 
 
-(defn parse-event [^Event payload]
+(defn parse-event
   "Parse native Binlog client event to Clojure data. Returns nil if
   the event has no parsing logic defined."
+  [^Event payload]
   (when-let [parser (-> payload
                         .getHeader
                         .getEventType

--- a/src/dumpa/stream.clj
+++ b/src/dumpa/stream.clj
@@ -9,8 +9,7 @@
             [dumpa.utils :as utils]
             [dumpa.row-format :as row-format]
             [dumpa.events :as events]
-            [dumpa.binlog :as binlog]
-            [dumpa.table-schema :as table-schema]))
+            [dumpa.binlog :as binlog]))
 
 (defn- preserving-reduced
   [rf]


### PR DESCRIPTION
This should allow us to inspect lifecycle events.

I think we could potentially install this on services that depend on `dumpa`, but I think it is ok to be opinionated here. Would rather know that dumpa will just provide useful logs

Fixes #5 